### PR TITLE
Add cron support to trigger schedule

### DIFF
--- a/teamcity/trigger_schedule.go
+++ b/teamcity/trigger_schedule.go
@@ -20,16 +20,37 @@ const (
 	TriggerSchedulingCron TriggerSchedulingPolicy = "cron"
 )
 
+type CronSchedule struct {
+	Seconds    string `prop:"cronExpression_sec"`
+	Minutes    string `prop:"cronExpression_min"`
+	Hours      string `prop:"cronExpression_hour"`
+	DayOfMonth string `prop:"cronExpression_dm"`
+	Month      string `prop:"cronExpression_month"`
+	DayOfWeek  string `prop:"cronExpression_dw"`
+	Year       string `prop:"cronExpression_year"`
+}
+
+func (cs *CronSchedule) properties() *Properties {
+	return serializeToProperties(cs)
+}
+
+func (p *Properties) cronSchedule() *CronSchedule {
+	var out CronSchedule
+	fillStructFromProperties(&out, p)
+	return &out
+}
+
 //TriggerSchedule represents a build trigger that fires on a time-bound schedule
 type TriggerSchedule struct {
 	triggerJSON *triggerJSON
 	buildTypeID string
 
 	SchedulingPolicy TriggerSchedulingPolicy `prop:"schedulingPolicy"`
-	Rules            []string                `prop:"triggerRules" separator:"\n"`
-	Timezone         string                  `prop:"timezone"`
-	Hour             uint                    `prop:"hour"`
-	Minute           uint                    `prop:"minute"`
+	CronExpression   *CronSchedule
+	Rules            []string `prop:"triggerRules" separator:"\n"`
+	Timezone         string   `prop:"timezone"`
+	Hour             uint     `prop:"hour"`
+	Minute           uint     `prop:"minute"`
 	Weekday          time.Weekday
 	Options          *TriggerScheduleOptions
 }
@@ -66,16 +87,16 @@ func (t *TriggerSchedule) SetBuildTypeID(id string) {
 
 //NewTriggerScheduleDaily returns a TriggerSchedule that fires daily on the hour/minute specified
 func NewTriggerScheduleDaily(sourceBuildID string, hour uint, minute uint, timezone string, rules []string) (*TriggerSchedule, error) {
-	return NewTriggerSchedule(TriggerSchedulingDaily, sourceBuildID, time.Sunday, hour, minute, timezone, rules, NewTriggerScheduleOptions())
+	return NewTriggerSchedule(TriggerSchedulingDaily, sourceBuildID, time.Sunday, hour, minute, timezone, rules, nil, NewTriggerScheduleOptions())
 }
 
 //NewTriggerScheduleWeekly returns a TriggerSchedule that fires weekly on the weekday and hour/minute specified
 func NewTriggerScheduleWeekly(sourceBuildID string, weekday time.Weekday, hour uint, minute uint, timezone string, rules []string) (*TriggerSchedule, error) {
-	return NewTriggerSchedule(TriggerSchedulingWeekly, sourceBuildID, weekday, hour, minute, timezone, rules, NewTriggerScheduleOptions())
+	return NewTriggerSchedule(TriggerSchedulingWeekly, sourceBuildID, weekday, hour, minute, timezone, rules, nil, NewTriggerScheduleOptions())
 }
 
 //NewTriggerSchedule returns a TriggerSchedule with the scheduling policy and options specified
-func NewTriggerSchedule(schedulingPolicy TriggerSchedulingPolicy, sourceBuildID string, weekday time.Weekday, hour uint, minute uint, timezone string, rules []string, opt *TriggerScheduleOptions) (*TriggerSchedule, error) {
+func NewTriggerSchedule(schedulingPolicy TriggerSchedulingPolicy, sourceBuildID string, weekday time.Weekday, hour uint, minute uint, timezone string, rules []string, cronSchedule *CronSchedule, opt *TriggerScheduleOptions) (*TriggerSchedule, error) {
 	if hour > 23 {
 		return nil, fmt.Errorf("invalid hour: %d, must be between 0-23", hour)
 	}
@@ -86,6 +107,14 @@ func NewTriggerSchedule(schedulingPolicy TriggerSchedulingPolicy, sourceBuildID 
 		return nil, fmt.Errorf("invalid weekday: %d, must be between time.Sunday and time.Saturday", weekday)
 	}
 
+	if cronSchedule != nil && schedulingPolicy != TriggerSchedulingCron {
+		return nil, fmt.Errorf("cron schedule is set, but cron scheduling policy was not chosen")
+	}
+
+	if schedulingPolicy == TriggerSchedulingCron && cronSchedule == nil {
+		return nil, fmt.Errorf("cron schedule must be specified if cron scheduling policy is chosen")
+	}
+
 	return &TriggerSchedule{
 		SchedulingPolicy: schedulingPolicy,
 		Timezone:         timezone,
@@ -94,6 +123,7 @@ func NewTriggerSchedule(schedulingPolicy TriggerSchedulingPolicy, sourceBuildID 
 		Hour:             hour,
 		Minute:           minute,
 		buildTypeID:      sourceBuildID,
+		CronExpression:   cronSchedule,
 
 		triggerJSON: &triggerJSON{
 			Disabled: NewFalse(),
@@ -129,6 +159,8 @@ func (t *TriggerSchedule) read(dt *triggerJSON) error {
 	switch t.SchedulingPolicy {
 	case TriggerSchedulingDaily, TriggerSchedulingWeekly:
 		return t.readDailyOrWeekly(dt)
+	case TriggerSchedulingCron:
+		t.CronExpression = t.triggerJSON.Properties.cronSchedule()
 	}
 
 	return nil
@@ -197,6 +229,13 @@ func (t *TriggerSchedule) MarshalJSON() ([]byte, error) {
 	optProps := t.Options.properties()
 	for _, p := range optProps.Items {
 		props.AddOrReplaceProperty(p)
+	}
+	if t.SchedulingPolicy == TriggerSchedulingCron {
+		if t.CronExpression == nil {
+			return nil, fmt.Errorf("cron expression was not specified")
+		}
+		cronProps := t.CronExpression.properties()
+		props = props.Concat(cronProps)
 	}
 
 	out := &triggerJSON{


### PR DESCRIPTION
Added the ability to specify a cron teamcity build trigger schedule.
The configuration would look like the following:
```
resource "teamcity_build_trigger_schedule" "schedule" {
  build_config_id = module.service.build_configs["commit"].id

  rules = [""]
  cron_schedule {
    seconds      = "5"
    minutes      = "8"
    hours        = "21"
    day_of_week  = "*"
    day_of_month = "*"
    month        = "12"
  }
  schedule = "cron"
}
```
Also added validation for the cron expression. Tested by using out of range numbers for the fields, and saw the expected errors.