### PR TITLE
Support BuildTriggerCustomization

### DIFF
--- a/teamcity/build_trigger_customization.go
+++ b/teamcity/build_trigger_customization.go
@@ -1,0 +1,11 @@
+package teamcity
+
+type BuildTriggerCustomization struct {
+	EnforceCleanCheckout                bool        `json:"enforceCleanCheckout"`
+	EnforceCleanCheckoutForDependencies bool        `json:"enforceCleanCheckoutForDependencies"`
+	Parameters                          *Parameters `json:"parameters,omitempty"`
+}
+
+func NewBuildTriggerCustomization() *BuildTriggerCustomization {
+	return &BuildTriggerCustomization{}
+}

--- a/teamcity/trigger_schedule.go
+++ b/teamcity/trigger_schedule.go
@@ -155,6 +155,7 @@ func (t *TriggerSchedule) read(dt *triggerJSON) error {
 	}
 
 	t.Options = t.triggerJSON.Properties.triggerScheduleOptions()
+	t.Options.BuildCustomization = t.triggerJSON.BuildCustomization
 
 	switch t.SchedulingPolicy {
 	case TriggerSchedulingDaily, TriggerSchedulingWeekly:
@@ -239,10 +240,11 @@ func (t *TriggerSchedule) MarshalJSON() ([]byte, error) {
 	}
 
 	out := &triggerJSON{
-		ID:         t.ID(),
-		Type:       t.Type(),
-		Disabled:   NewBool(t.Disabled()),
-		Properties: props,
+		ID:                 t.ID(),
+		Type:               t.Type(),
+		Disabled:           NewBool(t.Disabled()),
+		Properties:         props,
+		BuildCustomization: t.Options.BuildCustomization,
 	}
 
 	return json.Marshal(out)

--- a/teamcity/trigger_schedule_options.go
+++ b/teamcity/trigger_schedule_options.go
@@ -2,16 +2,16 @@ package teamcity
 
 //TriggerScheduleOptions represent options for configuring a scheduled build trigger
 type TriggerScheduleOptions struct {
-	QueueOptimization                   bool                       `prop:"enableQueueOptimization" force:""`
-	PromoteWatchedBuild                 bool                       `prop:"promoteWatchedBuild" force:""`
-	BuildWithPendingChangesOnly         bool                       `prop:"triggerBuildWithPendingChangesOnly" force:""`
-	TriggerIfWatchedBuildChanges        bool                       `prop:"triggerBuildIfWatchedBuildChanges"`
-	BuildOnAllCompatibleAgents          bool                       `prop:"triggerBuildOnAllCompatibleAgents"`
-	RevisionRuleSourceBuildID           string                     `prop:"revisionRuleDependsOn"`
-	RevisionRule                        ArtifactDependencyRevision `prop:"revisionRule"`
-	RevisionRuleBuildBranch             string                     `prop:"revisionRuleBuildBranch"`
-	EnforceCleanCheckout                bool                       `prop:"enforceCleanCheckout"`
-	EnforceCleanCheckoutForDependencies bool                       `prop:"enforceCleanCheckoutForDependencies"`
+	QueueOptimization            bool                       `prop:"enableQueueOptimization" force:""`
+	PromoteWatchedBuild          bool                       `prop:"promoteWatchedBuild" force:""`
+	BuildWithPendingChangesOnly  bool                       `prop:"triggerBuildWithPendingChangesOnly" force:""`
+	TriggerIfWatchedBuildChanges bool                       `prop:"triggerBuildIfWatchedBuildChanges"`
+	BuildOnAllCompatibleAgents   bool                       `prop:"triggerBuildOnAllCompatibleAgents"`
+	RevisionRuleSourceBuildID    string                     `prop:"revisionRuleDependsOn"`
+	RevisionRule                 ArtifactDependencyRevision `prop:"revisionRule"`
+	RevisionRuleBuildBranch      string                     `prop:"revisionRuleBuildBranch"`
+
+	BuildCustomization *BuildTriggerCustomization
 }
 
 //NewTriggerScheduleOptions returns a TriggerScheduleOptions with default values

--- a/teamcity/trigger_types.go
+++ b/teamcity/trigger_types.go
@@ -28,12 +28,13 @@ var TriggerTypes = struct {
 }
 
 type triggerJSON struct {
-	BuildTypeID string      `json:"-"`
-	Disabled    *bool       `json:"disabled,omitempty" xml:"disabled"`
-	Href        string      `json:"href,omitempty" xml:"href"`
-	ID          string      `json:"id,omitempty" xml:"id"`
-	Properties  *Properties `json:"properties,omitempty"`
-	Type        string      `json:"type,omitempty" xml:"type"`
+	BuildTypeID        string                     `json:"-"`
+	Disabled           *bool                      `json:"disabled,omitempty" xml:"disabled"`
+	Href               string                     `json:"href,omitempty" xml:"href"`
+	ID                 string                     `json:"id,omitempty" xml:"id"`
+	Properties         *Properties                `json:"properties,omitempty"`
+	BuildCustomization *BuildTriggerCustomization `json:"buildCustomization,omitempty" xml:"buildCustomization"`
+	Type               string                     `json:"type,omitempty" xml:"type"`
 }
 
 // Trigger represents a build trigger to be associated with a build configuration. Use the constructor methods to create new instances.


### PR DESCRIPTION
enforceCleanCheckout and enforceCleanCheckoutForDependencies are no longer in the property field, moved them to BuildTriggerCustomization according to the API change