### PR TITLE
Add move endpoint for build types

### DIFF
--- a/teamcity/build_type.go
+++ b/teamcity/build_type.go
@@ -1,6 +1,7 @@
 package teamcity
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -264,6 +265,17 @@ func (s *BuildTypeService) GetByID(id string) (*BuildType, error) {
 func (s *BuildTypeService) Rename(id string, name string) error {
 	locator := LocatorID(id).String()
 	_, err := s.restHelper.putTextPlain(locator+"/name", name, "build type name")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Move updates the parent project of the build type by sending a PUT request
+func (s *BuildTypeService) Move(id string, projectID string) error {
+	var out bytes.Buffer
+	locator := LocatorID(id).String()
+	err := s.restHelper.post(fmt.Sprintf("%s/move?targetProjectId=%s", locator, projectID), nil, &out, "build type project id")
 	if err != nil {
 		return err
 	}

--- a/teamcity/build_type.go
+++ b/teamcity/build_type.go
@@ -271,7 +271,7 @@ func (s *BuildTypeService) Rename(id string, name string) error {
 	return nil
 }
 
-// Move updates the parent project of the build type by sending a PUT request
+// Move updates the parent project of a build type by sending a POST request
 func (s *BuildTypeService) Move(id string, projectID string) error {
 	var out bytes.Buffer
 	locator := LocatorID(id).String()

--- a/teamcity/rest_helper.go
+++ b/teamcity/rest_helper.go
@@ -39,6 +39,10 @@ func (r *restHelper) getCustom(path string, out interface{}, resourceDescription
 	}
 
 	defer response.Body.Close()
+	if response.StatusCode == 204 {
+		return nil
+	}
+
 	bodyBytes, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return err
@@ -62,6 +66,9 @@ func (r *restHelper) get(path string, out interface{}, resourceDescription strin
 	}
 
 	defer response.Body.Close()
+	if response.StatusCode == 204 {
+		return nil
+	}
 
 	if response.StatusCode == 200 {
 		json.NewDecoder(response.Body).Decode(out)
@@ -82,6 +89,9 @@ func (r *restHelper) putCustom(path string, data interface{}, out interface{}, r
 		return err
 	}
 	defer response.Body.Close()
+	if response.StatusCode == 204 {
+		return nil
+	}
 
 	bodyBytes, err := ioutil.ReadAll(response.Body)
 	if err != nil {
@@ -106,6 +116,9 @@ func (r *restHelper) postCustom(path string, data interface{}, out interface{}, 
 		return err
 	}
 	defer response.Body.Close()
+	if response.StatusCode == 204 {
+		return nil
+	}
 
 	bodyBytes, err := ioutil.ReadAll(response.Body)
 	if err != nil {
@@ -132,22 +145,25 @@ func (r *restHelper) putTextPlain(path string, data string, resourceDescription 
 	if err != nil {
 		return "", err
 	}
-	resp, err := r.httpClient.Do(req)
+	response, err := r.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer response.Body.Close()
+	if response.StatusCode == 204 {
+		return "", nil
+	}
+
+	bodyBytes, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		return "", err
 	}
 
-	defer resp.Body.Close()
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-
-	if resp.StatusCode == 201 || resp.StatusCode == 200 {
+	if response.StatusCode == 201 || response.StatusCode == 200 {
 		return string(bodyBytes), nil
 	}
 
-	return "", r.handleRestError(bodyBytes, resp.StatusCode, "PUT", resourceDescription)
+	return "", r.handleRestError(bodyBytes, response.StatusCode, "PUT", resourceDescription)
 }
 
 func (r *restHelper) post(path string, data interface{}, out interface{}, resourceDescription string) error {
@@ -158,6 +174,9 @@ func (r *restHelper) post(path string, data interface{}, out interface{}, resour
 		return err
 	}
 	defer response.Body.Close()
+	if response.StatusCode == 204 {
+		return nil
+	}
 
 	if response.StatusCode == 201 || response.StatusCode == 200 {
 		json.NewDecoder(response.Body).Decode(out)
@@ -178,6 +197,9 @@ func (r *restHelper) put(path string, data interface{}, out interface{}, resourc
 		return err
 	}
 	defer response.Body.Close()
+	if response.StatusCode == 204 {
+		return nil
+	}
 
 	if response.StatusCode == 201 || response.StatusCode == 200 {
 		json.NewDecoder(response.Body).Decode(out)


### PR DESCRIPTION
This adds an additional method to allow users of the client to move a buildconfig instead of deleting and subsequently creating a new one.

The general rest helpers have also been updated to handle a 204 response code and to not treat them as errors.