### PR TITLE
Add support for snapshot dependency VCS triggers

### DIFF
--- a/teamcity/trigger_vcs.go
+++ b/teamcity/trigger_vcs.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-//TriggerVcs represents a build trigger on VCS changes
+// TriggerVcs represents a build trigger on VCS changes
 type TriggerVcs struct {
 	triggerJSON  *triggerJSON
 	buildTypeID  string
@@ -15,39 +15,39 @@ type TriggerVcs struct {
 	Options      *TriggerVcsOptions
 }
 
-//ID for this entity
+// ID for this entity
 func (t *TriggerVcs) ID() string {
 	return t.triggerJSON.ID
 }
 
-//Type returns TriggerTypes.Vcs ("vcsTrigger")
+// Type returns TriggerTypes.Vcs ("vcsTrigger")
 func (t *TriggerVcs) Type() string {
 	return TriggerTypes.Vcs
 }
 
-//SetDisabled controls whether this trigger is disabled or not
+// SetDisabled controls whether this trigger is disabled or not
 func (t *TriggerVcs) SetDisabled(disabled bool) {
 	t.triggerJSON.Disabled = NewBool(disabled)
 }
 
-//Disabled gets the disabled status for this trigger
+// Disabled gets the disabled status for this trigger
 func (t *TriggerVcs) Disabled() bool {
 	return *t.triggerJSON.Disabled
 }
 
-//BuildTypeID gets the build type identifier
+// BuildTypeID gets the build type identifier
 func (t *TriggerVcs) BuildTypeID() string {
 	return t.buildTypeID
 }
 
-//SetBuildTypeID sets the build type identifier
+// SetBuildTypeID sets the build type identifier
 func (t *TriggerVcs) SetBuildTypeID(id string) {
 	t.buildTypeID = id
 }
 
 // NewTriggerVcs returns a VCS trigger type with the triggerRules specified. triggerRules is required, but branchFilter can be optional if the VCS root uses multiple branches.
 func NewTriggerVcs(triggerRules []string, branchFilter []string) (*TriggerVcs, error) {
-	opt, err := NewTriggerVcsOptions(QuietPeriodDoNotUse, 0)
+	opt, err := NewTriggerVcsOptions(false, QuietPeriodDoNotUse, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +89,7 @@ func (t *TriggerVcs) properties() *Properties {
 	return props
 }
 
-//MarshalJSON implements JSON serialization for TriggerVcs
+// MarshalJSON implements JSON serialization for TriggerVcs
 func (t *TriggerVcs) MarshalJSON() ([]byte, error) {
 	out := &triggerJSON{
 		ID:         t.ID(),
@@ -101,7 +101,7 @@ func (t *TriggerVcs) MarshalJSON() ([]byte, error) {
 	return json.Marshal(out)
 }
 
-//UnmarshalJSON implements JSON deserialization for TriggerVcs
+// UnmarshalJSON implements JSON deserialization for TriggerVcs
 func (t *TriggerVcs) UnmarshalJSON(data []byte) error {
 	var aux triggerJSON
 	if err := json.Unmarshal(data, &aux); err != nil {

--- a/teamcity/trigger_vcs_options.go
+++ b/teamcity/trigger_vcs_options.go
@@ -22,17 +22,18 @@ type TriggerVcsOptions struct {
 	enableQueueOptimization bool
 	perCheckinTriggering    bool `prop:"branch"`
 
-	GroupUserCheckins    bool
-	QuietPeriodMode      VcsTriggerQuietPeriodMode
-	QuietPeriodInSeconds int
+	GroupUserCheckins          bool
+	SnapshotDependencyTriggers bool
+	QuietPeriodMode            VcsTriggerQuietPeriodMode
+	QuietPeriodInSeconds       int
 }
 
 // NewTriggerVcsOptions initialize a TriggerVcsOptions instance with same defaults as TeamCity UI
 //
 // Defaults:
-//	- GroupCheckins = false
-//	- EnableQueueOptimization = false
-func NewTriggerVcsOptions(mode VcsTriggerQuietPeriodMode, seconds int) (*TriggerVcsOptions, error) {
+//   - GroupCheckins = false
+//   - EnableQueueOptimization = true
+func NewTriggerVcsOptions(snapshotTriggers bool, mode VcsTriggerQuietPeriodMode, seconds int) (*TriggerVcsOptions, error) {
 	quietPeriodInSeconds := 0
 	if mode == QuietPeriodCustom {
 		if seconds <= 0 {
@@ -42,20 +43,21 @@ func NewTriggerVcsOptions(mode VcsTriggerQuietPeriodMode, seconds int) (*Trigger
 	}
 
 	return &TriggerVcsOptions{
-		perCheckinTriggering:    false,
-		enableQueueOptimization: true,
-		GroupUserCheckins:       false,
-		QuietPeriodMode:         mode,
-		QuietPeriodInSeconds:    quietPeriodInSeconds,
+		perCheckinTriggering:       false,
+		enableQueueOptimization:    true,
+		GroupUserCheckins:          false,
+		SnapshotDependencyTriggers: snapshotTriggers,
+		QuietPeriodMode:            mode,
+		QuietPeriodInSeconds:       quietPeriodInSeconds,
 	}, nil
 }
 
-//QueueOptimization gets the value of enableQueueOptimization property
+// QueueOptimization gets the value of enableQueueOptimization property
 func (o *TriggerVcsOptions) QueueOptimization() bool {
 	return o.enableQueueOptimization
 }
 
-//SetQueueOptimization toggles allowing the server to replace an already started build or a more recently queued one if new changes are detected. If set to true, PerCheckinTriggering will be disabled.
+// SetQueueOptimization toggles allowing the server to replace an already started build or a more recently queued one if new changes are detected. If set to true, PerCheckinTriggering will be disabled.
 func (o *TriggerVcsOptions) SetQueueOptimization(enable bool) {
 	o.enableQueueOptimization = enable
 	if enable {
@@ -63,7 +65,7 @@ func (o *TriggerVcsOptions) SetQueueOptimization(enable bool) {
 	}
 }
 
-//PerCheckinTriggering gets the value of perCheckinTriggering property
+// PerCheckinTriggering gets the value of perCheckinTriggering property
 func (o *TriggerVcsOptions) PerCheckinTriggering() bool {
 	return o.perCheckinTriggering
 }
@@ -109,6 +111,11 @@ func (o *TriggerVcsOptions) properties() *Properties {
 		props = append(props, p)
 	}
 
+	if o.SnapshotDependencyTriggers {
+		p := NewProperty("watchChangesInDependencies", "true")
+		props = append(props, p)
+	}
+
 	if o.QuietPeriodInSeconds > 0 {
 		p := NewProperty("quietPeriod", strconv.Itoa(o.QuietPeriodInSeconds))
 		props = append(props, p)
@@ -143,6 +150,15 @@ func (p *Properties) triggerVcsOptions() (*TriggerVcsOptions, error) {
 		}
 		if v2 {
 			out.SetPerCheckinTriggering(v2)
+		}
+	}
+	if v, ok := p.GetOk("watchChangesInDependencies"); ok {
+		v2, err := strconv.ParseBool(v)
+		if err != nil {
+			return nil, err
+		}
+		if v2 {
+			out.SnapshotDependencyTriggers = v2
 		}
 	}
 	if v, ok := p.GetOk("enableQueueOptimization"); ok {


### PR DESCRIPTION
VCS triggers have a checkbox "Trigger a build on changes in snapshot dependencies". Add support for that in the TeamCity Go client, which will be used later in the terraform-provider-teamcity

TEST=manual

Tested in conjunction with a corresponding change in terraform-provider-teamcity and verified it works.